### PR TITLE
在字符统计中包含行末换行符

### DIFF
--- a/Self-writtenCode/FileContentAnalyzer/FileContentAnalyzer.java
+++ b/Self-writtenCode/FileContentAnalyzer/FileContentAnalyzer.java
@@ -66,7 +66,11 @@ public class FileContentAnalyzer {
         try (var stream = Files.lines(filePath, StandardCharsets.UTF_8)) {
             for (String line : (Iterable<String>) stream::iterator) {
                 lines++;
-                chars += line.length();
+                // 原来：
+                // chars += line.length();
+                // 新增：把系统行分隔符也算入字符数
+                chars += line.length() + System.lineSeparator().length();
+            
                 String trimmed = line.trim();
                 if (!trimmed.isEmpty()) {
                     words += trimmed.split("\\s+").length;


### PR DESCRIPTION
当前统计字符数时只累加了每行的文字长度，不包括行尾的换行符；如果想精确统计文件中的所有字符（包括 \n 或 \r\n），需要把换行符长度也算上。